### PR TITLE
feat: long-time guests stats

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -49,6 +49,7 @@ async fn main() -> std::io::Result<()> {
                     .configure(services::guest::init_routes)
                     .configure(services::hotel::init_routes)
                     .configure(services::room::init_routes)
+                    .configure(services::stats::init_routes)
                     .configure(services::system::init_routes)
                     .configure(services::user::init_routes)
                     .wrap(services::session::middleware::CheckSession),

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -4,5 +4,6 @@ pub mod guest;
 pub mod hotel;
 pub mod room;
 pub mod session;
+pub mod stats;
 pub mod system;
 pub mod user;

--- a/backend/src/services/stats/mod.rs
+++ b/backend/src/services/stats/mod.rs
@@ -1,0 +1,5 @@
+mod model;
+mod routes;
+
+pub use model::*;
+pub use routes::init_routes;

--- a/backend/src/services/stats/model.rs
+++ b/backend/src/services/stats/model.rs
@@ -1,0 +1,47 @@
+use serde::Serialize;
+use sqlx::{query_as, FromRow};
+use time::PrimitiveDateTime;
+
+use crate::db;
+use crate::error::BackendError;
+use crate::utils::time::serialize_primitive_date_time_as_unix_timestamp;
+
+#[derive(Debug, FromRow, Serialize)]
+pub struct StatsLongTimeGuest {
+    pub guest_id: i64,
+    pub hotel_id: i64,
+    pub room_id: i64,
+    #[serde(serialize_with = "serialize_primitive_date_time_as_unix_timestamp")]
+    pub check_in_at: PrimitiveDateTime,
+    #[serde(serialize_with = "serialize_primitive_date_time_as_unix_timestamp")]
+    pub check_out_at: PrimitiveDateTime,
+}
+
+impl StatsLongTimeGuest {
+    pub async fn find_all_by_hotel_id(hotel_id: &i64) -> Result<Vec<Self>, BackendError> {
+        let connection = db::get_connection();
+
+        // TODO: Maybe someday interval will not be hardcoded
+        let guests = query_as!(
+            Self,
+            r#"
+                SELECT booking_guests.guest_id,
+                       bookings.hotel_id,
+                       bookings.room_id,
+                       bookings.check_in_at,
+                       bookings.check_out_at
+                FROM booking_guests
+                         LEFT JOIN bookings ON booking_guests.booking_id = bookings.id
+                WHERE bookings.hotel_id = $1
+                  AND bookings.check_in_at <= current_timestamp
+                  AND bookings.check_out_at > current_timestamp
+                  AND EXTRACT(DAY FROM current_timestamp - bookings.check_in_at) > 10;
+            "#,
+            hotel_id,
+        )
+        .fetch_all(connection)
+        .await?;
+
+        Ok(guests)
+    }
+}

--- a/backend/src/services/stats/routes.rs
+++ b/backend/src/services/stats/routes.rs
@@ -1,0 +1,38 @@
+use actix_web::web::{Path, ReqData, ServiceConfig};
+use actix_web::{get, HttpResponse};
+use serde::Deserialize;
+
+use crate::constants::DEFAULT_CONTENT_TYPE;
+use crate::error::{BackendError, BackendErrorTemplate};
+use crate::services::hotel::Hotel;
+use crate::services::session::Session;
+use crate::services::stats::StatsLongTimeGuest;
+
+#[derive(Deserialize)]
+struct GetStatsLongTimeGuestsPath {
+    hotel_id: i64,
+}
+
+#[get("/hotels/{hotel_id}/stats/long-time-guests")]
+async fn get_long_time_guests(
+    session: ReqData<Session>,
+    path: Path<GetStatsLongTimeGuestsPath>,
+) -> Result<HttpResponse, BackendError> {
+    let Some(user_id) = session.user_id else {
+        return Err(BackendErrorTemplate::Forbidden.into());
+    };
+
+    if Hotel::find(&path.hotel_id).await?.owner_id.ne(&user_id) {
+        return Err(BackendErrorTemplate::NotFound.into());
+    }
+
+    let guests = StatsLongTimeGuest::find_all_by_hotel_id(&path.hotel_id).await?;
+
+    Ok(HttpResponse::Created()
+        .content_type(DEFAULT_CONTENT_TYPE)
+        .body(rmp_serde::to_vec(&guests)?))
+}
+
+pub fn init_routes(cfg: &mut ServiceConfig) {
+    cfg.service(get_long_time_guests);
+}

--- a/desktop-client/src/app.cc
+++ b/desktop-client/src/app.cc
@@ -125,6 +125,7 @@ void Data::Clear() {
   guests.clear();
   rooms.clear();
   bookings.clear();
+  long_time_guests.clear();
 }
 
 Data data;

--- a/desktop-client/src/app.h
+++ b/desktop-client/src/app.h
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <imgui.h>
 #include <msgpack.hpp>
@@ -65,6 +66,8 @@ struct Data {
   std::unordered_map<entities::guest_id_t, entities::Guest> guests;
   std::unordered_map<entities::room_id_t, entities::Room> rooms;
   std::unordered_map<entities::booking_id_t, entities::Booking> bookings;
+  // TODO: maybe it's better to use something unordered
+  std::vector<entities::LongTimeGuest> long_time_guests;
 
   void Clear();
 };

--- a/desktop-client/src/backend/api.cc
+++ b/desktop-client/src/backend/api.cc
@@ -117,7 +117,7 @@ BackendRequest GetAllRooms(const entities::hotel_id_t hotel_id) {
 
 // Bookings
 BackendRequest CreateBooking(entities::hotel_id_t hotel_id,
-                          const CreateBookingRequestPayload &payload) {
+                             const CreateBookingRequestPayload &payload) {
   msgpack::sbuffer buffer;
   msgpack::pack(buffer, payload);
 
@@ -134,6 +134,14 @@ BackendRequest GetAllBookings(const entities::hotel_id_t hotel_id) {
   BackendRequest request(
       app::api_worker.Enqueue(std::format("/hotels/{}/bookings", hotel_id)),
       Layer::kApi);
+  return request;
+}
+
+// Stats
+BackendRequest GetStatsLongTimeGuests(const entities::hotel_id_t hotel_id) {
+  BackendRequest request(app::api_worker.Enqueue(std::format(
+                             "/hotels/{}/stats/long-time-guests", hotel_id)),
+                         Layer::kApi);
   return request;
 }
 }  // namespace backend

--- a/desktop-client/src/backend/backend.h
+++ b/desktop-client/src/backend/backend.h
@@ -222,12 +222,18 @@ struct CreateBookingRequestPayload {
 typedef entities::Booking create_booking_response_t;
 
 BackendRequest CreateBooking(entities::hotel_id_t hotel_id,
-                          const CreateBookingRequestPayload &payload);
+                             const CreateBookingRequestPayload &payload);
 
 // Get All Bookings
 typedef std::vector<entities::Booking> get_all_bookings_response_t;
 
 BackendRequest GetAllBookings(entities::hotel_id_t hotel_id);
+
+// Get Stats Long-Time Guests
+typedef std::vector<entities::LongTimeGuest>
+    get_stats_long_time_guests_response_t;
+
+BackendRequest GetStatsLongTimeGuests(entities::hotel_id_t hotel_id);
 
 template <typename T>
 ResponseStatus GetResponse(BackendRequest &request, T &response_reference) {

--- a/desktop-client/src/entities.h
+++ b/desktop-client/src/entities.h
@@ -489,6 +489,16 @@ struct Booking {
   MSGPACK_DEFINE(id, hotel_id, room_id, check_in_at, check_out_at, created_at,
                  guest_ids);
 };
+
+struct LongTimeGuest {
+  guest_id_t guest_id;
+  hotel_id_t hotel_id;
+  room_id_t room_id;
+  int64_t check_in_at;
+  int64_t check_out_at;
+
+  MSGPACK_DEFINE(guest_id, hotel_id, room_id, check_in_at, check_out_at);
+};
 }  // namespace entities
 
 #endif  // DESKTOP_CLIENT_ENTITIES_H

--- a/desktop-client/src/ui/screens/dashboard.cc
+++ b/desktop-client/src/ui/screens/dashboard.cc
@@ -2,30 +2,209 @@
 // Created by Mixerou on 18.12.2024.
 //
 
+#include <algorithm>
+#include <format>
+
+#include <imgui.h>
+
+#include "app.h"
+#include "backend.h"
 #include "constants.h"
 #include "layouts.h"
 #include "screens.h"
+#include "utils.h"
 #include "widgets.h"
 
 using namespace constants;
 
+enum class DashboardScreenRequestType {
+  kGetStatsLongTimeGuests,
+  kGetAllRooms,
+  kGetAllGuests,
+  kNone,
+};
+
+struct DashboardScreenState {
+  DashboardScreenRequestType request_type = DashboardScreenRequestType::kNone;
+  bool is_initial_retrieved = false;
+  backend::BackendRequest request;
+
+  DashboardScreenState() = default;
+};
+
+static auto dashboard_screen_state = DashboardScreenState();
+
+void DashboardLongTimeGuestsTable() {
+  if (!app::states::system.opened_hotel_id.has_value()) return;
+
+  const auto hotel_id = app::states::system.opened_hotel_id.value();
+  const auto available_region = ImGui::GetContentRegionAvail();
+  const float hardcoded_table_width = 640.f;
+
+  ImGui::SetCursorPosX(available_region.x / 2.f - hardcoded_table_width / 2.f);
+
+  ImVec2 top_left_header_point;
+  ImVec2 bottom_right_header_point;
+  ImVec2 top_left_body_point;
+  ImVec2 bottom_right_body_point;
+
+  if (ImGui::BeginTable("long_time_guests", 4, kDefaultTableFlags)) {
+    ImGui::TableSetupColumn("", kDefaultTableColumnFlags, 256.f);
+    ImGui::TableSetupColumn("", kDefaultTableColumnFlags, 128.f);
+    ImGui::TableSetupColumn("", kDefaultTableColumnFlags, 128.f);
+    ImGui::TableSetupColumn("", kDefaultTableColumnFlags, 128.f);
+
+    ImGui::TableHeadersRow();
+
+    ImGui::TableSetColumnIndex(0);
+    top_left_header_point = widgets::TableHeaderCellText("Guest").top_left;
+
+    ImGui::TableSetColumnIndex(1);
+    widgets::TableHeaderCellText("Room");
+
+    ImGui::TableSetColumnIndex(2);
+    widgets::TableHeaderCellText("Room group");
+
+    ImGui::TableSetColumnIndex(3);
+    bottom_right_header_point =
+        widgets::TableHeaderCellText("Lives (in days)").bottom_right;
+
+    int index = 0;
+    for (const auto& long_time_guest : app::states::data.long_time_guests) {
+      if (long_time_guest.hotel_id != hotel_id) continue;
+
+      const auto* guest = &app::states::data.guests[long_time_guest.guest_id];
+      const auto* room = &app::states::data.rooms[long_time_guest.room_id];
+
+      ImGui::PushID(std::format("long_time_guest{}", index).c_str());
+      ImGui::TableNextRow();
+
+      ImGui::TableSetColumnIndex(0);
+      const auto guest_name =
+          std::format("{} {}", guest->first_name, guest->last_name);
+      const auto first_cell_points = widgets::TableCellText(guest_name.c_str());
+
+      if (index == 0) top_left_body_point = first_cell_points.top_left;
+
+      ImGui::TableSetColumnIndex(1);
+      widgets::TableCellText(room->number.c_str());
+
+      ImGui::TableSetColumnIndex(2);
+      widgets::TableCellText(room->group_name.c_str());
+
+      ImGui::TableSetColumnIndex(3);
+      const int64_t live_time_difference =
+          (long_time_guest.check_out_at - long_time_guest.check_in_at) / 86400;
+      const auto second_cell_points =
+          widgets::TableCellText(std::to_string(live_time_difference).c_str());
+
+      // TODO: do not mutate every iteration
+      bottom_right_body_point = second_cell_points.bottom_right;
+
+      ImGui::PopID();
+
+      ++index;
+    }
+
+    ImGui::EndTable();
+  }
+
+  DrawTableHeaderBackground(widgets::TableCellScreenPosition(
+      top_left_header_point, bottom_right_header_point));
+  DrawTableBodyBackground(widgets::TableCellScreenPosition(
+      top_left_body_point, bottom_right_body_point));
+}
+
 namespace screens {
 void DashboardScreen() {
-  layouts::BeginAppLayout("Summary and Nerd Stats");
+  if (layouts::BeginAppLayout("Summary and Nerd Stats")) {
+    dashboard_screen_state = DashboardScreenState();
+  }
 
-  const auto available_region = ImGui::GetContentRegionAvail();
-  const auto viewport_work_size = ImGui::GetMainViewport()->WorkSize;
-  const auto occupied_size = ImVec2(viewport_work_size.x - available_region.x,
-                                    viewport_work_size.y - available_region.y);
+  if (!dashboard_screen_state.is_initial_retrieved) {
+    dashboard_screen_state.request_type =
+        DashboardScreenRequestType::kGetStatsLongTimeGuests;
+    dashboard_screen_state.is_initial_retrieved = true;
+    dashboard_screen_state.request = backend::GetStatsLongTimeGuests(
+        app::states::system.opened_hotel_id.value());
+  }
 
-  ImGui::SetNextWindowPos(
-      ImVec2(viewport_work_size.x / 2.f + occupied_size.x / 2.f,
-             viewport_work_size.y / 2.f + occupied_size.y / 2.f),
-      ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-  ImGui::BeginChild("info", ImVec2(), kChildWindowFitContent);
-  widgets::HeadingXlTextCenter("There is nothing to check");
-  ImGui::EndChild();
+  if (dashboard_screen_state.request_type ==
+      DashboardScreenRequestType::kGetStatsLongTimeGuests) {
+    backend::get_stats_long_time_guests_response_t long_time_guests_response;
+    const auto response =
+        GetResponse(dashboard_screen_state.request, long_time_guests_response);
 
-  layouts::EndAppLayout();
+    if (response != backend::ResponseStatus::kInProcess) {
+      app::states::data.long_time_guests.clear();
+      dashboard_screen_state.request_type =
+          DashboardScreenRequestType::kGetAllRooms;
+      dashboard_screen_state.request =
+          backend::GetAllRooms(app::states::system.opened_hotel_id.value());
+    }
+
+    if (response == backend::ResponseStatus::kCompleted)
+      for (const auto& guest : long_time_guests_response)
+        app::states::data.long_time_guests.push_back(guest);
+  }
+
+  else if (dashboard_screen_state.request_type ==
+           DashboardScreenRequestType::kGetAllRooms) {
+    backend::get_all_rooms_response_t get_all_rooms_response;
+    const auto response =
+        GetResponse(dashboard_screen_state.request, get_all_rooms_response);
+
+    if (response != backend::ResponseStatus::kInProcess) {
+      app::states::data.rooms.clear();
+      dashboard_screen_state.request_type =
+          DashboardScreenRequestType::kGetAllGuests;
+      dashboard_screen_state.request =
+          backend::GetAllGuests(app::states::system.opened_hotel_id.value());
+    }
+
+    if (response == backend::ResponseStatus::kCompleted)
+      for (const auto& room : get_all_rooms_response)
+        app::states::data.rooms[room.id] = room;
+  }
+
+  else if (dashboard_screen_state.request_type ==
+           DashboardScreenRequestType::kGetAllGuests) {
+    backend::get_all_guests_response_t get_all_guests_response;
+    const auto response =
+        GetResponse(dashboard_screen_state.request, get_all_guests_response);
+
+    if (response != backend::ResponseStatus::kInProcess) {
+      app::states::data.guests.clear();
+      dashboard_screen_state.request_type = DashboardScreenRequestType::kNone;
+    }
+
+    if (response == backend::ResponseStatus::kCompleted)
+      for (const auto& guest : get_all_guests_response)
+        app::states::data.guests[guest.id] = guest.ToGuest();
+  }
+
+  if (app::states::data.long_time_guests.empty()) {
+    const auto available_region = ImGui::GetContentRegionAvail();
+    const auto viewport_work_size = ImGui::GetMainViewport()->WorkSize;
+    const auto occupied_size =
+        ImVec2(viewport_work_size.x - available_region.x,
+               viewport_work_size.y - available_region.y);
+
+    ImGui::SetNextWindowPos(
+        ImVec2(viewport_work_size.x / 2.f + occupied_size.x / 2.f,
+               viewport_work_size.y / 2.f + occupied_size.y / 2.f),
+        ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::BeginChild("info", ImVec2(), kChildWindowFitContent);
+    widgets::HeadingXlTextCenter("There is nothing to check right now");
+    ImGui::EndChild();
+  } else {
+    ImGui::Spacing();
+    DashboardLongTimeGuestsTable();
+    ImGui::Spacing();
+  }
+
+  if (layouts::EndAppLayout()) {
+    dashboard_screen_state = DashboardScreenState();
+  }
 }
 }  // namespace screens


### PR DESCRIPTION
### Backend

- new GET endpoint: `/hotels/{hotel_id}/stats/long-time-guests`

### Desktop Client

- complete `dashboard` screen
